### PR TITLE
Remove directions for verifying local-persist.

### DIFF
--- a/administrators/manual/installing/docker.md
+++ b/administrators/manual/installing/docker.md
@@ -178,15 +178,6 @@ Verify that Local-Persist is running and enabled at startup:
 *   `sudo systemctl is-active docker-volume-local-persist` should say `active`
 *   `sudo systemctl is-enabled docker-volume-local-persist` should say `enabled`
 
-Also verify that Local-Persist is registered with Docker:
-
-*   `sudo -u lockss docker info` should have a `Plugins` section with lists of volume, network and log plugins. The `Volume` list under the `Plugins` section should contain `local-persist`. Here is an excerpt of `docker info` output showing that Local-Persist is correctly registered as a Docker volume plugin:
-
-        Plugins:
-         Volume: local local-persist
-         Network: bridge host macvlan null overlay
-         Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
-
 ## Reconfiguring Docker
 
 This section describes what to do when Docker needs to be reconfigured. **You do not need to do anything unless one of the sections above sends you here.**


### PR DESCRIPTION
Docker plugins are [loaded only when they are used](<https://docs.docker.com/engine/extend/plugin_api/#plugin-activation>), so, at this point in the installation process, the plugin will not be listed in the output from `docker info`. We could direct the user to create and destroy a test volume, but, in the unlikely event the plugin is not recognized by Docker, `assemble-lockss` will fail with a clear error message, so checking manually seems to me unnecessary.

For thoroughness, here's a [Vagrantfile](https://github.com/lockss/lockss.github.io/files/3934033/Vagrantfile.txt) demonstrating the problem.
